### PR TITLE
Resolved a problem with embedded mongoid documents and boolean selectors

### DIFF
--- a/app/views/rails_admin/main/_form_boolean.html.erb
+++ b/app/views/rails_admin/main/_form_boolean.html.erb
@@ -2,9 +2,9 @@
   <div class="btn-group" role="group">
     <% {'1': [true, 'btn-outline-success'], '0': [false, 'btn-outline-danger'], '': [nil, 'btn-outline-secondary']}.each do |text, (value, btn_class)| %>
       <%= form.radio_button field.method_name, text, field.html_attributes.reverse_merge({ checked: field.form_value == value, required: field.required, class: 'btn-check' }) %>
-      <label for="<%= form.object_name %>_<%= field.method_name %>_<%= text %>" class="<%= field.css_classes[value] %> btn <%= btn_class %>">
+      <%= form.label "#{field.method_name}_#{text}", class: "#{field.css_classes[value]} btn #{btn_class}" do %>
         <%= field.labels[value].html_safe %>
-      </label>
+      <% end %>
     <% end %>
   </div>
 <% else %>


### PR DESCRIPTION
Previous implementation was creating a label with an incorrect for attribute when used on an embedded mongoid document. It would create <label for=parent_class[embedded_class_attributes]_field_name_1 ... when the id of the input field was parent_class_embedded_class_attributes_field_name_1. Because of this the selectors did nothing when clicked since the label references an id that does not exist. This change to using the rails label helper should safely create the label in all cases.